### PR TITLE
package.json is now using main attribute for autoload

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "name": "Sebastiaan Deckers",
     "email": "seb@ninja.sg"
   },
+  "main": "googletagmanager.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:cofounders/googletagmanager.git"


### PR DESCRIPTION
Hi,

I'm editing a React project, and `require()` method is looking for `index.js` file which not exists.
Using `main` attribute fixes javascript main file load.
